### PR TITLE
🆙🚀 binder-tuto (v1.0) by loic tetrel et al.

### DIFF
--- a/data/nlbooks/binder-tuto.json
+++ b/data/nlbooks/binder-tuto.json
@@ -1,0 +1,36 @@
+{
+  "associated_publication": [
+    {
+      "citation": "https://github.com/ltetrel/binder-tuto",
+      "url": "https://github.com/ltetrel/binder-tuto"
+    }
+  ],
+  "authors": [
+    {
+      "affiliation": "Please type in your affiliation here. For multiple affiliations, see the next author entry",
+      "name": "loic tetrel",
+      "website": "https://github.com/ltetrel"
+    },
+    {
+      "affiliation": [
+        "Affiliation 1",
+        "Affiliation 2"
+      ],
+      "name": "Another Author",
+      "website": "If availabe, this entry can point to author's GitHub page or personal website. Please delete this line if not available."
+    }
+  ],
+  "keywords": [
+    "kw1",
+    "kw2"
+  ],
+  "submission": {
+    "assignee": "agahkarakuzu",
+    "category": "Publication",
+    "date": "2020-05-29T00:00:00.000Z",
+    "id": 15,
+    "upstream": "https://github.com/ltetrel/binder-tuto"
+  },
+  "summary": "Please add a brief (50-60 words) summary of your work. This summary will appear at the publication card (https://neurolibre.com)",
+  "title": "my submission"
+}


### PR DESCRIPTION
<p align="center" ><img src="https://github.com/roboneurotest/binder-tuto/blob/master/binder-tuto_featured.png?raw=true" alt="featured" width="300"><p align="center">
<hr>

### my submission

#### 🤖 This pull request has been automatially created from [binder-tuto](https://github.com/roboneurotest/binder-tuto) repository.            

## 🛫 Checklist 

[![Version badge](https://img.shields.io/badge/pub-v1.0-green)](https://github.com/roboneurotest/binder-tuto/releases/tag/pub-v1.0) [![Status badge](https://github.com/roboneurotest/binder-tuto/workflows/Publish%20to%20neurolibre.com/badge.svg?branch=pub-v1.0)](https://github.com/roboneurotest/binder-tuto/actions) [![Book](https://img.shields.io/badge/NeuroLibreBook-binder-tuto-red.svg?&style=flat&color=ff0000)](https://neurolibre.com)

- [ ] **Build is passing**
  It may take some time status badge to fetch status (green|pass or red|fail). Click the badge to monitor the process in real time.
<br>

- [ ] **Publication is properly versioned**
   Click the badge to see the associated release in the source repository. Publication tags respect `pub-v*` format, where suffix is always `v1` for the first version. 
<br>

- [ ] **Publication is live**
   It may take publication for a while to go live after a successful build due to page build and domain resolution. Note that the publication pages are built from the `gh-pages` branch of the source repository. 
<br>

- [ ] **[Added publication metadata](https://github.com/roboneurotest/website-test/blob/binder-tuto/data/nlbooks/binder-tuto.json) is OK.**
<br>

- [ ] **Badges are properly populated on the publication card and the links are not broken.** 
<br>

- [ ] **Featured image is visible on the publication card.**
<br>
       
<hr>
<p align="center"><img src="https://www.neurolibre.com/img/neurolibre_logo.svg" alt="featured" width="50"/><br>NeuroLibre</p>